### PR TITLE
Ajout de la version anglaise du mur de mémoire (DMJ-972)

### DIFF
--- a/mur_de_memoire_en.html
+++ b/mur_de_memoire_en.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Memory Wall – DMJ-972</title>
+</head>
+<body>
+<nav>
+  <a href="index_en.html">Home</a> |
+  <a href="mur_de_memoire_en.html">Memory Wall</a> |
+  <a href="assistant_juridique.html">Legal Aid</a> |
+  <a href="temoignages_timeline.html">Testimonies</a> |
+  <a href="contact.html">Contact</a>
+</nav>
+<h1>🕊️ Memory Wall – In Honor of the 112 Victims of Flight DMJ-972</h1>
+<p>This space is dedicated to remembrance, truth, and justice. Below is the list of victims. Their names must never be forgotten.</p>
+
+<ul>
+  <li><strong>Mailén Díaz Almaguer</strong></li>
+  <li><strong>José Alberto González</strong></li>
+  <li><strong>Danay Victoria Álvarez</strong></li>
+  <li><strong>... et 109 autres victimes</strong></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Ajout de la page mur_de_memoire_en.html avec traduction des textes en anglais. Les noms des victimes ont été conservés dans leur forme originale. Navigation adaptée à la version EN.